### PR TITLE
[Fix] Disable plugin action for unexpected syntaxes

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,12 +1,29 @@
-[
-  { "keys": ["tab"], "command": "github_emoji_auto_complete", "args": { "isCommitEmoji":true }, "context":
-    [
-      { "key": "preceding_text", "operator": "regex_contains", "operand": "@$", "match_all": true }
-    ]
-  },
-  { "keys": ["tab"], "command": "github_emoji_auto_complete", "args": {}, "context":
-    [
-      { "key": "preceding_text", "operator": "regex_contains", "operand": ":$", "match_all": true }
-    ]
-  }
-]
+[{
+    "keys": ["tab"],
+    "command": "github_emoji_auto_complete",
+    "args": {
+        "isCommitEmoji": true
+    },
+    "context": [{
+        "key": "preceding_text",
+        "operator": "regex_contains",
+        "operand": "@$",
+        "match_all": true
+    }, {
+        "key": "selector",
+        "operand": "text.html.markdown, text.html.markdown.multimarkdown, text.html.markdown.gfm, text.html.markdown.academicmarkdown"
+    }]
+}, {
+    "keys": ["tab"],
+    "command": "github_emoji_auto_complete",
+    "args": {},
+    "context": [{
+        "key": "preceding_text",
+        "operator": "regex_contains",
+        "operand": ":$",
+        "match_all": true
+    }, {
+        "key": "selector",
+        "operand": "text.html.markdown, text.html.markdown.multimarkdown, text.html.markdown.gfm, text.html.markdown.academicmarkdown"
+    }]
+}]

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -11,7 +11,7 @@
         "match_all": true
     }, {
         "key": "selector",
-        "operand": "text.html.markdown, text.html.markdown.multimarkdown, text.html.markdown.gfm, text.html.markdown.academicmarkdown"
+        "operand": "text.html.markdown, text.html.markdown.multimarkdown, text.html.markdown.gfm, text.html.markdown.academicmarkdown, text.html.markdown.academicyaml"
     }]
 }, {
     "keys": ["tab"],
@@ -24,6 +24,6 @@
         "match_all": true
     }, {
         "key": "selector",
-        "operand": "text.html.markdown, text.html.markdown.multimarkdown, text.html.markdown.gfm, text.html.markdown.academicmarkdown"
+        "operand": "text.html.markdown, text.html.markdown.multimarkdown, text.html.markdown.gfm, text.html.markdown.academicmarkdown, text.html.markdown.academicyaml"
     }]
 }]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,12 +1,29 @@
-[
-  { "keys": ["tab"], "command": "github_emoji_auto_complete", "args": { "isCommitEmoji":true }, "context":
-    [
-      { "key": "preceding_text", "operator": "regex_contains", "operand": "@$", "match_all": true }
-    ]
-  },
-  { "keys": ["tab"], "command": "github_emoji_auto_complete", "args": {}, "context":
-    [
-      { "key": "preceding_text", "operator": "regex_contains", "operand": ":$", "match_all": true }
-    ]
-  }
-]
+[{
+    "keys": ["tab"],
+    "command": "github_emoji_auto_complete",
+    "args": {
+        "isCommitEmoji": true
+    },
+    "context": [{
+        "key": "preceding_text",
+        "operator": "regex_contains",
+        "operand": "@$",
+        "match_all": true
+    }, {
+        "key": "selector",
+        "operand": "text.html.markdown, text.html.markdown.multimarkdown, text.html.markdown.gfm, text.html.markdown.academicmarkdown"
+    }]
+}, {
+    "keys": ["tab"],
+    "command": "github_emoji_auto_complete",
+    "args": {},
+    "context": [{
+        "key": "preceding_text",
+        "operator": "regex_contains",
+        "operand": ":$",
+        "match_all": true
+    }, {
+        "key": "selector",
+        "operand": "text.html.markdown, text.html.markdown.multimarkdown, text.html.markdown.gfm, text.html.markdown.academicmarkdown"
+    }]
+}]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -11,7 +11,7 @@
         "match_all": true
     }, {
         "key": "selector",
-        "operand": "text.html.markdown, text.html.markdown.multimarkdown, text.html.markdown.gfm, text.html.markdown.academicmarkdown"
+        "operand": "text.html.markdown, text.html.markdown.multimarkdown, text.html.markdown.gfm, text.html.markdown.academicmarkdown, text.html.markdown.academicyaml"
     }]
 }, {
     "keys": ["tab"],
@@ -24,6 +24,6 @@
         "match_all": true
     }, {
         "key": "selector",
-        "operand": "text.html.markdown, text.html.markdown.multimarkdown, text.html.markdown.gfm, text.html.markdown.academicmarkdown"
+        "operand": "text.html.markdown, text.html.markdown.multimarkdown, text.html.markdown.gfm, text.html.markdown.academicmarkdown, text.html.markdown.academicyaml"
     }]
 }]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,12 +1,29 @@
-[
-  { "keys": ["tab"], "command": "github_emoji_auto_complete", "args": { "isCommitEmoji":true }, "context":
-    [
-      { "key": "preceding_text", "operator": "regex_contains", "operand": "@$", "match_all": true }
-    ]
-  },
-  { "keys": ["tab"], "command": "github_emoji_auto_complete", "args": {}, "context":
-    [
-      { "key": "preceding_text", "operator": "regex_contains", "operand": ":$", "match_all": true }
-    ]
-  }
-]
+[{
+    "keys": ["tab"],
+    "command": "github_emoji_auto_complete",
+    "args": {
+        "isCommitEmoji": true
+    },
+    "context": [{
+        "key": "preceding_text",
+        "operator": "regex_contains",
+        "operand": "@$",
+        "match_all": true
+    }, {
+        "key": "selector",
+        "operand": "text.html.markdown, text.html.markdown.multimarkdown, text.html.markdown.gfm, text.html.markdown.academicmarkdown"
+    }]
+}, {
+    "keys": ["tab"],
+    "command": "github_emoji_auto_complete",
+    "args": {},
+    "context": [{
+        "key": "preceding_text",
+        "operator": "regex_contains",
+        "operand": ":$",
+        "match_all": true
+    }, {
+        "key": "selector",
+        "operand": "text.html.markdown, text.html.markdown.multimarkdown, text.html.markdown.gfm, text.html.markdown.academicmarkdown"
+    }]
+}]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -11,7 +11,7 @@
         "match_all": true
     }, {
         "key": "selector",
-        "operand": "text.html.markdown, text.html.markdown.multimarkdown, text.html.markdown.gfm, text.html.markdown.academicmarkdown"
+        "operand": "text.html.markdown, text.html.markdown.multimarkdown, text.html.markdown.gfm, text.html.markdown.academicmarkdown, text.html.markdown.academicyaml"
     }]
 }, {
     "keys": ["tab"],
@@ -24,6 +24,6 @@
         "match_all": true
     }, {
         "key": "selector",
-        "operand": "text.html.markdown, text.html.markdown.multimarkdown, text.html.markdown.gfm, text.html.markdown.academicmarkdown"
+        "operand": "text.html.markdown, text.html.markdown.multimarkdown, text.html.markdown.gfm, text.html.markdown.academicmarkdown, text.html.markdown.academicyaml"
     }]
 }]


### PR DESCRIPTION
### 1. Summary

I make, that GitHub Emoji works only for Markdown syntaxes.

### 2. Behavior before pull request

**If**:

    I works in non-Markdown syntaxes, →

    GitHub Emoji prevents me

__Example for__:

    Python syntax:

        I can't indent block:

![Before](https://imgur.com/BdU5ZuZ.png)

### 3. Behavior after pull request

**For**:

+ Markdown syntax — GitHub Emoji command run,
+ Another syntax — command for syntax run.

![After](https://imgur.com/6ilYB3M.png)

### 4. Argumentation

Users don't needs GitHub Emoji for non-Markdown syntaxes, GitHub Emoji prevents them. I want to use <kbd>Tab</kbd> for another actions.

### 5. Testing environment

+ Windows 10 Enterprise LTSB 64-bit EN,
+ Sublime Text Build 3143,
+ GitHub Emoji 1.2.0,
+ Latest versions of Markdown syntaxes from section below.

### 6. Supported syntaxes

1. Default:

    1. [**Markdown**](https://github.com/sublimehq/Packages/blob/master/Markdown/Markdown.sublime-syntax),
    1. [**MultiMarkdown**](https://github.com/sublimehq/Packages/blob/master/Markdown/MultiMarkdown.sublime-syntax).

1. [**MarkdownHighlighting**](https://github.com/braver/MarkdownHighlighting/blob/master/Markdown.sublime-syntax).

1. MarkdownLight:

    1. [**MarkdownLight**](https://github.com/sekogan/MarkdownLight/blob/master/MarkdownLight.tmLanguage),
    1. [**MarkdownLight.YAML**](https://github.com/sekogan/MarkdownLight/blob/master/MarkdownLight.YAML-tmLanguage).

1. MarkdownEditing:

    1. [**Markdown (Standard)**](https://github.com/SublimeText-Markdown/MarkdownEditing/blob/master/Markdown%20(Standard).tmLanguage),
    1. [**MultiMarkdown**](https://github.com/SublimeText-Markdown/MarkdownEditing/blob/master/MultiMarkdown.tmLanguage),
    1. [**Markdown GFM**](https://github.com/SublimeText-Markdown/MarkdownEditing/blob/master/Markdown.sublime-syntax).

1. AcademicMarkdown:

    1. [**AcademicMarkdown**](https://github.com/mangecoeur/AcademicMarkdown/blob/master/AcademicMarkdown.tmLanguage),
    1. [**AcademicYAML**](https://github.com/mangecoeur/AcademicMarkdown/blob/master/AcademicYaml.tmLanguage).

I doesn't find another non-deprecated Markdown syntax in Package Control.

**If** these syntaxes __exists__:

    we need to add them.

Thanks.