### PR TITLE
:bug: update git commit scope to work in ST4

### DIFF
--- a/GithubEmoji.sublime-settings
+++ b/GithubEmoji.sublime-settings
@@ -1548,7 +1548,8 @@
   ],
   "emojiScopes": [
     "text.html.markdown",
-    "text.git-commit"
+    "text.git-commit",
+    "text.git.commit"
   ],
   "emojiFileNames": [
     "COMMIT_EDITMSG"


### PR DESCRIPTION
In ST4 the commit scope changed from `-commit` to `.commit`